### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,370 @@ bottom-up as the CFG rules are reduced. Semantic actions, coded in
 Lua, can introduce custom nodes in the AST and traverse built-in nodes
 using the visitor pattern.
 
-BasilCC uses default reductions to minimize the size _and_ number of
-states in the FSM. Two states (with the same kernel rules) are
+BasilCC generates default reductions to minimize the size _and_ number
+of states in the FSM. Two states (with the same kernel rules) are
 collapsed into one if both produce the same shift and reduce actions
-over all possible lookahead tokens, and the same holds true recursively
-over all pairwise state transitions. The FSM provides the power of LR
-with minimum overhead.
+over all possible lookahead tokens, and the same holds true
+recursively over all pairwise state transitions. The FSM provides the
+power of LR with minimum overhead.
+
+## Grammar File
+
+BasilCC takes as input a grammar file containing rules and
+directives. Anything to the right of a pound sign (#) is a comment.
+
+A rule states that a symbol, a noterminal, can expand to zero or more
+symbols. The nonterminal is on the left-hand side of an arrow, and the
+symbols to which it can expand are on the right. A symbol with all
+upper case letters is a token, a nonterminal otherwise.
+
+For example here is a CFG accepting zero or more Ys followed by one Z.
+
+```
+start -> y-seq Z
+y-seq ->
+y-seq -> y-seq Y
+```
+
+A rule with the nonterminal 'start' on the left side is a start rule,
+and it indicates a root in the CFG. The CFG must have at least one such
+rule.
+
+Attributes can follow a symbol and are used to assign lexical state,
+resolve parsing conflicts, and mark accepting reductions. Attributes
+influence the symbol in the context of the rule only. More on
+attributes below.
+
+An AST node type can be paired with a rule by following the left-hand
+side symbol with an identifier in square brackets, after any
+attributes. The identifier, normalized, is the type name. The
+identifier is normalized by capitalizing the first letter of each
+word, treating (then removing) the underscore and minus sign as word
+delimiters.
+
+If a node type is paired with a rule then an instance of the type, a
+node, is created when the rule is reduced. The node's array (the node
+is a Lua table) will contain a child node for each right-hand side
+symbol. If you define an "onNode" method then it is called when the
+rule is reduced, and the return value replaces the node. Unless the
+rule is start rule, the node will represent the left-hand side symbol
+as a child in a later reduction.
+
+Here is a simple expression CFG. Five node types are 
+introduced: AddExpr1, AddExpr2, MulExpr1, MulExpr2 and Factor.
+
+```
+start -> add-expr
+add-expr [add-expr1] -> add-expr PLUS mul-expr
+add-expr [add-expr2] -> add-expr MINUS mul-expr
+add-expr-> mul-expr
+mul-expr [mul-expr1] -> mul-expr TIMES factor
+mul-expr [mul-expr2] -> mul-expr DIVIDE factor
+mul-expr -> factor
+factor [factor] -> NUMBER
+```
+
+A percent sign as the first non-whitespace character on a line starts
+a directive. Unlike a rule, a directive cannot extend over one
+line. There are two kinds of directives.
+
+A _keyword_ directive states that a token is a keyword with the given
+lexeme (or spelling). The list of lexemes -- each paired with a unique
+token number -- is stored in the FSM, so they can be referenced by
+your lexer. Here are a few examples:
+
+```
+%keyword CLASS "class"
+%keyword INT "int"
+%keyword NAMESPACE "namespace"
+```
+
+A _recover_ directive adds a recover strategy on syntax errors. The
+parser can insert a token, or discard some number of
+tokens. Here are a few examples:
+
+```
+%recover insert SEMI
+%recover insert RBRACE
+%recover discard 5
+```
+
+The strategies are stored in the FSM in the order they appear. At
+runtime when the parser encounters a syntax error it will backtrack to
+the last accepting state and attempt the strategies in order. If the
+parser reaches an accepting state it recovers and continues, otherwise
+it aborts with a syntax error.
+
+## Attributes
+
+### Lexical State
+
+Every LR parser state has a lexical state. The lexical state is an
+integer that is derived from all possible lookahead tokens. The parser
+consumes tokens on demand, calling a function in the lexer when it
+requires the next one. The current lexical state (the one associated
+with the current LR parser state) is passed to the lexer on this call,
+allowing the lexer to make context sensitive decisions when forming the
+next token.
+
+The lexical state assigned to a symbol, in its context only, transfers
+to all tokens in the symbol's first set.
+
+For example the CFG below will accept one of two token sequences, A B
+C B or B C B. Assuming valid input, the lexical state on the first
+call to the lexer (to get B or A) will be 1. The lexical state to get
+the second B will be 2.
+
+```
+start -> a-opt b 1 C b 2
+a-opt -> A
+a-opt ->  
+b -> B
+```
+
+BasilCC will report a lexical state conflict if there are competing
+lexical states in the CFG. Here is an example:
+
+```
+start -> a-opt B 2
+a-opt -> A 1
+a-opt ->
+```
+
+Note when the parser backtracks it may discard some tokens. The parser
+will cache those tokens and reuse them when advancing -- backtracking
+does not extend to the lexer.
+
+### Accept
+
+Performing a backtracking LR parse is akin to searching a tree in
+depth-first search order. A shift/reduce or a reduce/reduce conflict
+introduces a branch in the tree. On a conflict the parser will try the
+first action -- if that one results in a failed parse then the parser
+will backtrack and try the other (the actions are ordered using the
+priories described below).
+
+An accepting reduction will cause the parser to cancel any pending
+constructions of the rule's right-hand side. If, after the reduction,
+there _no_ pending constructions then the reduction produces an
+accepting state.
+
+The accept attribute, *, is used to indicate an accepting reduction.
+
+If the accept attribute is on a rule's left-hand side symbol then when
+the rule is reduced it is an accepting reduction. Note the accept
+property is not assigned to the rule. Instead, it is assigned to all
+tokens in the rule's follow set. If a
+token in a follow set has the accept property then it produces an
+accepting reduction. This distinction is important when considering
+the case of an accept attribute on a right-hand side nonterminal.
+ 
+If the accept attribute is on a right-hand side nonterminal then all
+tokens that follow it are assigned the accept property when they are
+collected to form the follow set for rules with the same symbol on the
+left-hand side.
+
+It's a good idea to trigger accepting states even when the CFG has no
+conflicts. When the parser encounters a syntax error it will backtrack
+to the last accepting state. If there are no accepting states then the
+parser will backtrack to the start and recover only if it can parse
+the entire token stream successfully (after applying a recover
+strategy).
+
+It's also important to trigger an accepting state after performing
+semantic actions that influence the program state.
+
+Below is an example. The CFG accepts a sequence of declarations. To
+keep it simple suppose a declaration can be A, B or C followed by a
+semi-colon. If semantic actions add the declarations to the scope --
+influencing the program state -- then you should indicate that all
+three are accepting reductions.
+
+```
+start -> decl-seq
+decl-seq -> decl-seq decl
+decl-seq -> decl
+decl -> any-decl SEMI
+any-decl * [a-decl] -> A
+any-decl * [b-decl] -> B
+any-decl * [c-decl] -> C
+```
+
+### Sticky
+
+Because BasilCC generates default reductions a rule may be reduced
+when any token is next -- not only just the set of tokens that are
+valid in that context. To prevent this use the sticky attribute, <.
+
+If a sticky attribute is on a rule's left-hand side symbol then that
+rule will be reduced only if a valid token is next. Like the accept
+attribute, the sticky property is not assigned to the rule, instead it
+is assigned to all tokens in the rule's follow set, and sticky tokens
+are not considered when searching for the rule's default reduction.
+
+If a sticky attribute is on a right-hand side nonterminal then all
+tokens that follow it are assigned the sticky property when they are
+collected to form the follow set for rules with the same symbol on the
+left-hand side.
+
+Consider the last example. The 3 rules with 'any-decl' on the left
+hand side will be reduced when any token is next. To make sure the
+reductions occur only when a SEMI is next use a sticky attribute:
+
+```
+start -> decl-seq
+decl-seq -> decl-seq decl
+decl-seq -> decl
+decl -> any-decl *< SEMI
+any-decl [a-decl] -> A
+any-decl [b-decl] -> B
+any-decl [c-decl] -> C
+```
+
+### Shift, Reduce and First Priority
+
+The priority attributes are used to order the actions on shift/reduce and
+reduce/reduce conflicts. The parser will try the actions on a conflict
+in order, highest priority first. BasilCC will report an error if the
+actions are not ordered.
+
+First consider a shift/reduce conflict:
+
+```
+start -> a-opt A
+a-opt -> A
+a-opt ->
+```
+
+This CFG will accept one A or two As. To shift first give the optional
+A a shift priority using the shift priority attribute, >:
+
+```
+start -> a-opt A
+a-opt -> A >
+a-opt ->
+```
+  
+The attribute can also be used on the right-hand side:
+
+```
+start -> a-opt > A
+a-opt -> A
+a-opt ->
+```
+
+This results in same order, but here you're saying shift first in this
+context only.
+
+Consider:
+
+```
+start -> a-opt > A X a-opt + A
+a-opt -> A
+a-opt ->
+```
+
+Now 'a-opt' is used in two contexts, before and after an X. After the
+X the 'a-opt' is given a reduce priority, +.  So after the X the parser
+will reduce first.
+
+The same can be done by using a first priority, ^, on the last A:
+
+```
+start -> a-opt > A X a-opt A ^
+a-opt -> A
+a-opt ->
+```
+
+Here's a more contrived example that shows when you might prefer to
+use a first priority:
+
+```
+start -> a-or-b-opt > b-opt ^^ A
+a-or-b-opt -> a-or-b
+a-or-b-opt -> 
+a-or-b -> A
+a-or-b -> B
+b-opt -> B
+b-opt ->
+```
+
+Here the parser will shift first on A, but reduce first on B.
+
+Note
+
+* Priorities have reach (for the lack of a better word). Note
+  'a-or-b-opt' is given a shift priority above -- this in turn gives
+  'a-or-b' shift priority and this in turn gives both A and B shift
+  priority. Priorities have unlimited reach.
+
+* Priorities are additive. Note the 2 first priorities on 'b-opt'
+  above. The shift priority on 'a-or-b-opt' gives the shift action on
+  the optional B priority. So to reduce first you need to give the
+  reduce action 2 priorities.
+
+The same can be done using priorities on the tokens directly:
+
+```
+start -> a-or-b-opt b-opt A
+a-or-b-opt -> a-or-b
+a-or-b-opt -> 
+a-or-b -> A >
+a-or-b -> B
+b-opt -> B ^
+b-opt ->
+```
+
+Here 1 first priority on B is sufficient. Note that the
+first priority on B influences the ordering of actions on the start
+rule. First priorities have unlimited _reverse_ reach.
+
+Here's another example:
+
+```
+start -> a
+a -> b >
+a -> c
+b -> A x-opt B
+c -> A y-opt B
+x-opt -> T
+x-opt ->
+y-opt -> T
+y-opt -> 
+```
+
+Note the conflict after shifting A. If B is next there's a
+reduce/reduce conflict. If T is next there's another reduce/reduce
+conflict after shifting it. But because 'b' is given a shift priority
+both conflicts are ordered in favor of 'b'. This has real
+applications. In C++ you favor a declaration over an
+expression. Implementing this is simple:
+
+```
+stmt -> expr
+stmt -> decl >
+```
+
+Finally, what if after ordering actions you want to ignore the ones
+with the lower priority -- that is, you don't want the parser to
+guess. A bang, !, after any priority drops any actions with lower
+priority.
+
+Here's an example:
+
+```
+start -> a-opt +! A
+a-opt -> A
+a-opt ->
+```
+
+Here the parser will always reduce, never backtrack. Again, this has
+real applications. In C++ the greater-than sign in a template-id is
+never a relational operator:
+
+```
+template-id -> name LT arg-seq GT ^!
+```
+
+The '>' in 'A<1>x' is always closing the template-id. Very simple
+to implement.

--- a/basilscripts/basil_app.lua
+++ b/basilscripts/basil_app.lua
@@ -2,9 +2,9 @@
 
 local nodes = require 'basil_nodes'
 
--- rule-name -> IDENT EQUALS
-function nodes.RuleName:onNode()
-   return self[1].lexeme
+-- node-type -> LBRACK IDENT RBRACK
+function nodes.NodeType:onNode()
+   return self[2].lexeme
 end
 
 -- attrib-seq < ->
@@ -67,9 +67,9 @@ function nodes.SymbolSeq2:onNode()
    return self[1]
 end
 
--- rule <* -> rule-name-opt symbol ARROW symbol-seq-opt >
+-- rule <* -> symbol node-type-opt ARROW symbol-seq-opt >
 function nodes.Rule:onNode()
-   basil.rule{self[1], left_symbol=self[2], right_symbols=self[4]}
+   basil.rule{self[2], left_symbol=self[1], right_symbols=self[4]}
 end
 
 -- bang-seq -> BANG
@@ -80,4 +80,13 @@ end
 -- bang-seq -> bang-seq BANG
 function nodes.BangSeq2:onNode()
    return self[1] + 1
+end
+
+-- deprecated rule syntax
+-- rule -> IDENT COLON symbol ARROW symbol-seq-opt >
+-- RuleDeprecated a node only after 2nd bootstrap
+if nodes.RuleDeprecated then
+  function nodes.RuleDeprecated:onNode()
+     basil.rule{self[1].lexeme, left_symbol=self[3], right_symbols=self[5]}
+  end
 end

--- a/basilscripts/basil_bootstrap.lua
+++ b/basilscripts/basil_bootstrap.lua
@@ -9,10 +9,10 @@ rule{left_symbol='rule-seq-opt'}
 rule{left_symbol='rule-seq-opt', right_symbols={'rule-seq'}}
 rule{left_symbol='rule-seq', right_symbols={'rule'}}
 rule{left_symbol='rule-seq', right_symbols={'rule-seq', 'rule'}}
-rule{'rule', left_symbol='rule', right_symbols={symbol{'rule-name-opt', shift_priority=1}, 'symbol', 'ARROW', symbol{'symbol-seq-opt', shift_priority=1}}}
-rule{left_symbol='rule-name-opt'}
-rule{left_symbol='rule-name-opt', right_symbols={symbol{'rule-name', accept=true}}}
-rule{'rule_name', left_symbol='rule-name', right_symbols={'IDENT', 'COLON'}}
+rule{'rule', left_symbol='rule', right_symbols={'symbol', 'node-type-opt', 'ARROW', symbol{'symbol-seq-opt', shift_priority=1}}}
+rule{left_symbol='node-type-opt'}
+rule{left_symbol='node-type-opt', right_symbols={'node-type'}}
+rule{'node_type', left_symbol='node-type', right_symbols={'LBRACK', 'IDENT', 'RBRACK'}}
 rule{left_symbol='symbol-seq-opt'}
 rule{left_symbol='symbol-seq-opt', right_symbols={'symbol-seq'}}
 rule{'symbol_seq_1', left_symbol='symbol-seq', right_symbols={'symbol'}}

--- a/basilscripts/basil_rules.txt
+++ b/basilscripts/basil_rules.txt
@@ -1,7 +1,7 @@
-# basil rule grammar
+# basil grammar
 #
-# After bootstraping grammar parser suggest generating the parser again using this file to pick up the
-# syntax error recover strategies
+# BasilCC after initial bootstrap will regenerate its FSM from this CFG
+#
 
 start -> rule-seq-opt
 
@@ -11,35 +11,39 @@ rule-seq-opt -> rule-seq
 rule-seq -> rule
 rule-seq -> rule-seq rule
 
-rule: rule -> rule-name-opt > symbol ARROW symbol-seq-opt >
+rule [rule] -> symbol node-type-opt ARROW symbol-seq-opt >
 
-rule-name-opt ->
-rule-name-opt -> rule-name *
+# this was old format, node type preceding rule, still used by lzz3
+# find CFG easier to read if left-hand side symbol always first
+rule [rule_deprecated] -> IDENT COLON symbol ARROW symbol-seq-opt >
 
-rule_name: rule-name -> IDENT COLON
+node-type-opt ->
+node-type-opt -> node-type
+
+node-type [node_type] -> LBRACK IDENT RBRACK
 
 symbol-seq-opt ->
 symbol-seq-opt -> symbol-seq
 
-symbol_seq_1: symbol-seq -> symbol
-symbol_seq_2: symbol-seq -> symbol-seq symbol
+symbol-seq [symbol_seq_1] -> symbol
+symbol-seq [symbol_seq_2] -> symbol-seq symbol
 
 # will add symbol on reduction so keep follow symbols sticky, only reduce if valid tokens follow
-symbol: symbol <* -> IDENT attrib-seq
+symbol <* [symbol] -> IDENT attrib-seq
 
-attrib_seq_1: attrib-seq -> 
-attrib_seq_2: attrib-seq -> attrib-seq NUMBER
-attrib_seq_3: attrib-seq -> attrib-seq LT
-attrib_seq_4: attrib-seq -> attrib-seq STAR
-attrib_seq_5: attrib-seq -> attrib-seq PLUS  bang-seq-opt
-attrib_seq_6: attrib-seq -> attrib-seq CARET bang-seq-opt
-attrib_seq_7: attrib-seq -> attrib-seq GT    bang-seq-opt
+attrib-seq [attrib_seq_1] -> 
+attrib-seq [attrib_seq_2] -> attrib-seq NUMBER
+attrib-seq [attrib_seq_3] -> attrib-seq LT
+attrib-seq [attrib_seq_4] -> attrib-seq STAR
+attrib-seq [attrib_seq_5] -> attrib-seq PLUS  bang-seq-opt
+attrib-seq [attrib_seq_6] -> attrib-seq CARET bang-seq-opt
+attrib-seq [attrib_seq_7] -> attrib-seq GT    bang-seq-opt
 
 bang-seq-opt -> 
 bang-seq-opt -> bang-seq
 
-bang_seq_1: bang-seq -> BANG
-bang_seq_2: bang-seq -> bang-seq BANG
+bang-seq [bang_seq_1] -> BANG
+bang-seq [bang_seq_2] -> bang-seq BANG
 
-# try discarding max of 1 token on syntax error
-%recover discard 1
+# try discarding up to 3 tokens on syntax error
+%recover discard 3

--- a/src/basilcc/follow_closure.lzz
+++ b/src/basilcc/follow_closure.lzz
@@ -46,9 +46,8 @@ namespace
           SymbolPtr symbol = base_rule->getNextSymbol ();
           if (! symbol->isToken ())
           {
-            // todo: use auto_ptr
-            FollowPtr follow = follow_rule->getNextFollow ();
-            update (symbol, follow);
+            auto_ptr <Follow> follow (follow_rule->getNextFollow());
+            update (symbol, follow.get());
           }
         }
       }

--- a/src/basilcc/follow_rule.lzz
+++ b/src/basilcc/follow_rule.lzz
@@ -66,7 +66,6 @@ namespace basilcc
       }
       if (null)
       {
-        // why not also next_rule_symbol shift priority?
         rp = left_rule_symbol->getReducePriority () + next_rule_symbol->getReducePriority ();
         if (rule->canBypass ())
         {

--- a/src/basilccapp/basilccapp.lzz
+++ b/src/basilccapp/basilccapp.lzz
@@ -224,8 +224,10 @@ namespace
   {
     cout << "boostrapping rule FSM ..." << endl;
     int print_state_flags = 0;
+    // create initial FSM from bootstrap lua file  
     (Bootstrap (scripts_dir, print_state_flags) ());
-    (CompileGrammar (scripts_dir, print_state_flags) (join (scripts_dir, BASIL_RULES), "basil"));
+    // then use FSM to regenerate it from basil rules
+    (CompileGrammar (scripts_dir, print_state_flags)(join(scripts_dir, BASIL_RULES), join(scripts_dir, "basil")));
     cout << "done" << endl;
   }
 


### PR DESCRIPTION
1. Update readme
2. Fix 2nd bootstrap
3. Switch to new rule syntax, node-type-opt after left-hand symbol, old format still supported as used by lzz3